### PR TITLE
fixing error UnicodeDecodeError: 'ascii' codec can't decode byte 0xa0 in position 0: ordinal not in range(128)

### DIFF
--- a/html2vimdoc.py
+++ b/html2vimdoc.py
@@ -291,6 +291,7 @@ def decode_hexadecimal_entities(html):
     def decode_entity(match):
         character = chr(int(match.group(1), 16))
         return unsafe_to_decode.get(character, character)
+    html = html.encode("utf8")
     return re.sub(r'&#x([0-9A-Fa-f]+);', decode_entity, html)
 
 def find_root_node(tree, selector):


### PR DESCRIPTION
```
negor@vm3095:~/javascripting/fthelp/vim-tools$ html2vimdoc/bin/python ./html2vimdoc.py ../arguments.md > ../arguments.txt
2015-04-04 10:33:59 vm3095 html2vimdoc[29272] INFO Reading input from ../arguments.md ..
2015-04-04 10:33:59 vm3095 html2vimdoc[29272] INFO Converting Markdown to HTML using extensions: fenced_code.
2015-04-04 10:33:59 vm3095 html2vimdoc[29272] INFO Parsing HTML ..
Traceback (most recent call last):
  File "./html2vimdoc.py", line 1269, in <module>
    main()
  File "./html2vimdoc.py", line 97, in main
    vimdoc = html2vimdoc(text, title=title, filename=filename, url=url)
  File "./html2vimdoc.py", line 184, in html2vimdoc
    html = decode_hexadecimal_entities(html)
  File "./html2vimdoc.py", line 294, in decode_hexadecimal_entities
    return re.sub(r'&#x([0-9A-Fa-f]+);', decode_entity, html)
  File "/home/negor/javascripting/fthelp/vim-tools/html2vimdoc/lib/python2.7/re.py", line 151, in sub
    return _compile(pattern, flags).sub(repl, string, count)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xa0 in position 0: ordinal not in range(128)
```
